### PR TITLE
Completely removed the "Speed up Disc Transfer Rate" option

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -86,7 +86,6 @@ private:
   int iSyncGpuMaxDistance;
   int iSyncGpuMinDistance;
   float fSyncGpuOverclock;
-  bool bFastDiscSpeed;
   bool bDSPHLE;
   bool bHLE_BS2;
   int iSelectedLanguage;
@@ -119,7 +118,6 @@ void ConfigCache::SaveConfig(const SConfig& config)
   iSyncGpuMaxDistance = config.iSyncGpuMaxDistance;
   iSyncGpuMinDistance = config.iSyncGpuMinDistance;
   fSyncGpuOverclock = config.fSyncGpuOverclock;
-  bFastDiscSpeed = config.bFastDiscSpeed;
   bDSPHLE = config.bDSPHLE;
   bHLE_BS2 = config.bHLE_BS2;
   iSelectedLanguage = config.SelectedLanguage;
@@ -165,7 +163,6 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->iSyncGpuMaxDistance = iSyncGpuMaxDistance;
   config->iSyncGpuMinDistance = iSyncGpuMinDistance;
   config->fSyncGpuOverclock = fSyncGpuOverclock;
-  config->bFastDiscSpeed = bFastDiscSpeed;
   config->bDSPHLE = bDSPHLE;
   config->bHLE_BS2 = bHLE_BS2;
   config->SelectedLanguage = iSelectedLanguage;
@@ -263,7 +260,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     core_section->Get("MMU", &StartUp.bMMU, StartUp.bMMU);
     core_section->Get("LowDCBZHack", &StartUp.bLowDCBZHack, StartUp.bLowDCBZHack);
     core_section->Get("SyncGPU", &StartUp.bSyncGPU, StartUp.bSyncGPU);
-    core_section->Get("FastDiscSpeed", &StartUp.bFastDiscSpeed, StartUp.bFastDiscSpeed);
     core_section->Get("DSPHLE", &StartUp.bDSPHLE, StartUp.bDSPHLE);
     core_section->Get("CPUCore", &StartUp.cpu_core, StartUp.cpu_core);
     core_section->Get("HLE_BS2", &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
@@ -327,7 +323,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     StartUp.bCPUThread = Config::Get(Config::MAIN_CPU_THREAD);
     StartUp.bJITFollowBranch = Config::Get(Config::MAIN_JIT_FOLLOW_BRANCH);
     StartUp.bDSPHLE = Config::Get(Config::MAIN_DSP_HLE);
-    StartUp.bFastDiscSpeed = Config::Get(Config::MAIN_FAST_DISC_SPEED);
     StartUp.cpu_core = Config::Get(Config::MAIN_CPU_CORE);
     StartUp.bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
     if (!StartUp.bWii)
@@ -377,7 +372,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     StartUp.iSyncGpuMinDistance = netplay_settings.m_SyncGpuMinDistance;
     StartUp.fSyncGpuOverclock = netplay_settings.m_SyncGpuOverclock;
     StartUp.bJITFollowBranch = netplay_settings.m_JITFollowBranch;
-    StartUp.bFastDiscSpeed = netplay_settings.m_FastDiscSpeed;
     StartUp.bMMU = netplay_settings.m_MMU;
     StartUp.bFastmem = netplay_settings.m_Fastmem;
     StartUp.bHLE_BS2 = netplay_settings.m_SkipIPL;

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -89,7 +89,6 @@ const Info<bool> MAIN_SYNC_GPU{{System::Main, "Core", "SyncGPU"}, false};
 const Info<int> MAIN_SYNC_GPU_MAX_DISTANCE{{System::Main, "Core", "SyncGpuMaxDistance"}, 200000};
 const Info<int> MAIN_SYNC_GPU_MIN_DISTANCE{{System::Main, "Core", "SyncGpuMinDistance"}, -200000};
 const Info<float> MAIN_SYNC_GPU_OVERCLOCK{{System::Main, "Core", "SyncGpuOverclock"}, 1.0f};
-const Info<bool> MAIN_FAST_DISC_SPEED{{System::Main, "Core", "FastDiscSpeed"}, false};
 const Info<bool> MAIN_LOW_DCBZ_HACK{{System::Main, "Core", "LowDCBZHack"}, false};
 const Info<bool> MAIN_FPRF{{System::Main, "Core", "FPRF"}, false};
 const Info<bool> MAIN_ACCURATE_NANS{{System::Main, "Core", "AccurateNaNs"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -70,7 +70,6 @@ extern const Info<bool> MAIN_SYNC_GPU;
 extern const Info<int> MAIN_SYNC_GPU_MAX_DISTANCE;
 extern const Info<int> MAIN_SYNC_GPU_MIN_DISTANCE;
 extern const Info<float> MAIN_SYNC_GPU_OVERCLOCK;
-extern const Info<bool> MAIN_FAST_DISC_SPEED;
 extern const Info<bool> MAIN_LOW_DCBZ_HACK;
 extern const Info<bool> MAIN_FPRF;
 extern const Info<bool> MAIN_ACCURATE_NANS;

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -29,7 +29,6 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
 {
   config_layer->Set(Config::MAIN_CPU_THREAD, dtm->bDualCore);
   config_layer->Set(Config::MAIN_DSP_HLE, dtm->bDSPHLE);
-  config_layer->Set(Config::MAIN_FAST_DISC_SPEED, dtm->bFastDiscSpeed);
   config_layer->Set(Config::MAIN_CPU_CORE, static_cast<PowerPC::CPUCore>(dtm->CPUCore));
   config_layer->Set(Config::MAIN_SYNC_GPU, dtm->bSyncGPU);
   config_layer->Set(Config::MAIN_GFX_BACKEND, dtm->videoBackend.data());
@@ -52,7 +51,6 @@ void SaveToDTM(Movie::DTMHeader* dtm)
 {
   dtm->bDualCore = Config::Get(Config::MAIN_CPU_THREAD);
   dtm->bDSPHLE = Config::Get(Config::MAIN_DSP_HLE);
-  dtm->bFastDiscSpeed = Config::Get(Config::MAIN_FAST_DISC_SPEED);
   dtm->CPUCore = static_cast<u8>(Config::Get(Config::MAIN_CPU_CORE));
   dtm->bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
   const std::string video_backend = Config::Get(Config::MAIN_GFX_BACKEND);

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -61,7 +61,6 @@ public:
     layer->Set(Config::MAIN_SYNC_GPU_MIN_DISTANCE, m_settings.m_SyncGpuMinDistance);
     layer->Set(Config::MAIN_SYNC_GPU_OVERCLOCK, m_settings.m_SyncGpuOverclock);
     layer->Set(Config::MAIN_JIT_FOLLOW_BRANCH, m_settings.m_JITFollowBranch);
-    layer->Set(Config::MAIN_FAST_DISC_SPEED, m_settings.m_FastDiscSpeed);
     layer->Set(Config::MAIN_MMU, m_settings.m_MMU);
     layer->Set(Config::MAIN_FASTMEM, m_settings.m_Fastmem);
     layer->Set(Config::MAIN_SKIP_IPL, m_settings.m_SkipIPL);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -506,7 +506,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("SyncGpuMaxDistance", &iSyncGpuMaxDistance, 200000);
   core->Get("SyncGpuMinDistance", &iSyncGpuMinDistance, -200000);
   core->Get("SyncGpuOverclock", &fSyncGpuOverclock, 1.0f);
-  core->Get("FastDiscSpeed", &bFastDiscSpeed, false);
   core->Get("LowDCBZHack", &bLowDCBZHack, false);
   core->Get("FPRF", &bFPRF, false);
   core->Get("AccurateNaNs", &bAccurateNaNs, false);
@@ -747,7 +746,6 @@ void SConfig::LoadDefaults()
   bLowDCBZHack = false;
   iBBDumpPort = -1;
   bSyncGPU = false;
-  bFastDiscSpeed = false;
   bEnableMemcardSdWriting = true;
   SelectedLanguage = 0;
   bOverrideRegionSettings = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -133,7 +133,6 @@ struct SConfig
   bool bMMU = false;
   bool bLowDCBZHack = false;
   int iBBDumpPort = 0;
-  bool bFastDiscSpeed = false;
 
   bool bSyncGPU = false;
   int iSyncGpuMaxDistance;

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -98,7 +98,7 @@ struct DTMHeader
   bool bDualCore;
   bool bProgressive;
   bool bDSPHLE;
-  bool bFastDiscSpeed;
+  bool bFastDiscSpeed; // Unused in this custom speedrunning version
   u8 CPUCore;  // Uses the values of PowerPC::CPUCore
   bool bEFBAccessEnable;
   bool bEFBCopyEnable;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -688,7 +688,6 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_SyncGpuMinDistance;
       packet >> m_net_settings.m_SyncGpuOverclock;
       packet >> m_net_settings.m_JITFollowBranch;
-      packet >> m_net_settings.m_FastDiscSpeed;
       packet >> m_net_settings.m_MMU;
       packet >> m_net_settings.m_Fastmem;
       packet >> m_net_settings.m_SkipIPL;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -54,7 +54,6 @@ struct NetSettings
   int m_SyncGpuMinDistance;
   float m_SyncGpuOverclock;
   bool m_JITFollowBranch;
-  bool m_FastDiscSpeed;
   bool m_MMU;
   bool m_Fastmem;
   bool m_SkipIPL;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1333,7 +1333,6 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_SyncGpuMinDistance;
   spac << m_settings.m_SyncGpuOverclock;
   spac << m_settings.m_JITFollowBranch;
-  spac << m_settings.m_FastDiscSpeed;
   spac << m_settings.m_MMU;
   spac << m_settings.m_Fastmem;
   spac << m_settings.m_SkipIPL;

--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -38,10 +38,6 @@ GameConfigEdit::GameConfigEdit(QWidget* parent, QString path, bool read_only)
                                                  "enabled. Can improve performance but can also "
                                                  "cause issues. Defaults to <b>True</b>"));
 
-  AddDescription(QStringLiteral("FastDiscSpeed"),
-                 tr("Shortens loading times but may break some games. Can have negative effects on "
-                    "performance. Defaults to <b>False</b>"));
-
   AddDescription(QStringLiteral("MMU"), tr("Controls whether or not the Memory Management Unit "
                                            "should be emulated fully. Few games require it."));
 

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -89,7 +89,6 @@ void GameConfigWidget::CreateWidgets()
   m_enable_mmu = new QCheckBox(tr("Enable MMU"));
   m_enable_fprf = new QCheckBox(tr("Enable FPRF"));
   m_sync_gpu = new QCheckBox(tr("Synchronize GPU thread"));
-  m_enable_fast_disc = new QCheckBox(tr("Speed up Disc Transfer Rate"));
   m_use_dsp_hle = new QCheckBox(tr("DSP HLE (fast)"));
   m_deterministic_dual_core = new QComboBox;
 
@@ -103,14 +102,11 @@ void GameConfigWidget::CreateWidgets()
                                "games. (ON = Compatible, OFF = Fast)"));
   m_sync_gpu->setToolTip(tr("Synchronizes the GPU and CPU threads to help prevent random freezes "
                             "in Dual core mode. (ON = Compatible, OFF = Fast)"));
-  m_enable_fast_disc->setToolTip(tr("Enable fast disc access. This can cause crashes and other "
-                                    "problems in some games. (ON = Fast, OFF = Compatible)"));
 
   core_layout->addWidget(m_enable_dual_core, 0, 0);
   core_layout->addWidget(m_enable_mmu, 1, 0);
   core_layout->addWidget(m_enable_fprf, 2, 0);
   core_layout->addWidget(m_sync_gpu, 3, 0);
-  core_layout->addWidget(m_enable_fast_disc, 4, 0);
   core_layout->addWidget(m_use_dsp_hle, 5, 0);
   core_layout->addWidget(new QLabel(tr("Deterministic dual core:")), 6, 0);
   core_layout->addWidget(m_deterministic_dual_core, 6, 1);
@@ -160,7 +156,7 @@ void GameConfigWidget::CreateWidgets()
   general_layout->addWidget(m_refresh_config, 1, 0, 1, -1);
 
   for (QCheckBox* item : {m_enable_dual_core, m_enable_mmu, m_enable_fprf, m_sync_gpu,
-                          m_enable_fast_disc, m_use_dsp_hle, m_use_monoscopic_shadows})
+                          m_use_dsp_hle, m_use_monoscopic_shadows})
     item->setTristate(true);
 
   auto* general_widget = new QWidget;
@@ -207,7 +203,7 @@ void GameConfigWidget::ConnectWidgets()
   connect(m_refresh_config, &QPushButton::clicked, this, &GameConfigWidget::LoadSettings);
 
   for (QCheckBox* box : {m_enable_dual_core, m_enable_mmu, m_enable_fprf, m_sync_gpu,
-                         m_enable_fast_disc, m_use_dsp_hle, m_use_monoscopic_shadows})
+                         m_use_dsp_hle, m_use_monoscopic_shadows})
     connect(box, &QCheckBox::stateChanged, this, &GameConfigWidget::SaveSettings);
 
   connect(m_deterministic_dual_core, qOverload<int>(&QComboBox::currentIndexChanged), this,
@@ -278,7 +274,6 @@ void GameConfigWidget::LoadSettings()
   LoadCheckBox(m_enable_mmu, "Core", "MMU");
   LoadCheckBox(m_enable_fprf, "Core", "FPRF");
   LoadCheckBox(m_sync_gpu, "Core", "SyncGPU");
-  LoadCheckBox(m_enable_fast_disc, "Core", "FastDiscSpeed");
   LoadCheckBox(m_use_dsp_hle, "Core", "DSPHLE");
 
   std::string determinism_mode;
@@ -328,7 +323,6 @@ void GameConfigWidget::SaveSettings()
   SaveCheckBox(m_enable_mmu, "Core", "MMU");
   SaveCheckBox(m_enable_fprf, "Core", "FPRF");
   SaveCheckBox(m_sync_gpu, "Core", "SyncGPU");
-  SaveCheckBox(m_enable_fast_disc, "Core", "FastDiscSpeed");
   SaveCheckBox(m_use_dsp_hle, "Core", "DSPHLE");
 
   int determinism_num = m_deterministic_dual_core->currentIndex();

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.h
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.h
@@ -49,7 +49,6 @@ private:
   QCheckBox* m_enable_mmu;
   QCheckBox* m_enable_fprf;
   QCheckBox* m_sync_gpu;
-  QCheckBox* m_enable_fast_disc;
   QCheckBox* m_use_dsp_hle;
   QCheckBox* m_use_monoscopic_shadows;
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -479,7 +479,6 @@ void NetPlayDialog::OnStart()
   settings.m_SyncGpuMinDistance = Config::Get(Config::MAIN_SYNC_GPU_MIN_DISTANCE);
   settings.m_SyncGpuOverclock = Config::Get(Config::MAIN_SYNC_GPU_OVERCLOCK);
   settings.m_JITFollowBranch = Config::Get(Config::MAIN_JIT_FOLLOW_BRANCH);
-  settings.m_FastDiscSpeed = Config::Get(Config::MAIN_FAST_DISC_SPEED);
   settings.m_MMU = Config::Get(Config::MAIN_MMU);
   settings.m_Fastmem = Config::Get(Config::MAIN_FASTMEM);
   settings.m_SkipIPL = Config::Get(Config::MAIN_SKIP_IPL) ||


### PR DESCRIPTION
Since this is a speedrunning specific version. I figured may as well remove a banned option that invalidates runs. Whether it was used intentionally or not.